### PR TITLE
specify width of nDMABREQ

### DIFF
--- a/mc6809e.v
+++ b/mc6809e.v
@@ -41,7 +41,7 @@ module mc6809e(
 
 
 mc6809i cpucore (.D(D), .DOut(DOut), .ADDR(ADDR), .RnW(RnW), .E(E), .Q(Q), .BS(BS), .BA(BA), .nIRQ(nIRQ), .nFIRQ(nFIRQ), 
-                .nNMI(nNMI), .AVMA(AVMA), .BUSY(BUSY), .LIC(LIC), .nHALT(nHALT), .nRESET(nRESET), .nDMABREQ(1)
+                .nNMI(nNMI), .AVMA(AVMA), .BUSY(BUSY), .LIC(LIC), .nHALT(nHALT), .nRESET(nRESET), .nDMABREQ(1'b1)
                 );
 
 


### PR DESCRIPTION
Fixes a warning when using the mc6809e core in Icarus Verilog 11.0.