### PR TITLE
Set N and Z flags for SEX instruction.

### DIFF
--- a/mc6809i.v
+++ b/mc6809i.v
@@ -1973,6 +1973,7 @@ begin
                         a_nxt = {8{b[7]}};
                         cc_nxt[CC_N_BIT] = b[7];
                         cc_nxt[CC_Z_BIT] = {b == 8'H00};
+                        cc_nxt[CC_V_BIT] = 1'b0;
                         rLIC = 1'b1; // Instruction done!
                         rAVMA = 1'b1;
                         CpuState_nxt = CPUSTATE_FETCH_I1;

--- a/mc6809i.v
+++ b/mc6809i.v
@@ -1971,6 +1971,8 @@ begin
                     else if (Inst1 == OPCODE_INH_SEX)
                     begin
                         a_nxt = {8{b[7]}};
+                        cc_nxt[CC_N_BIT] = b[7];
+                        cc_nxt[CC_Z_BIT] = {b == 8'H00};
                         rLIC = 1'b1; // Instruction done!
                         rAVMA = 1'b1;
                         CpuState_nxt = CPUSTATE_FETCH_I1;


### PR DESCRIPTION
The SEX instruction misses to set N and Z flags.
This PR adds respective logic to update N and Z according to B's content.

Update: Clear the V flag unconditionally, courtesy of Jotego.
* https://github.com/jotego/jt_gng/blob/stable/doc/MC6809_DataSheet.pdf
* http://atjs.mbnet.fi/mc6809/Information/6809.htm