### PR TITLE
Fix: SWI3 should detect it is a page 3 instruction

### DIFF
--- a/mc6809i.v
+++ b/mc6809i.v
@@ -3832,7 +3832,7 @@ begin
         CpuState_nxt = CPUSTATE_IRQ_DONTCARE;
         if (InstPage3)
             IntType_nxt = INTTYPE_SWI3;
-        if (InstPage2)
+        else if (InstPage2)
             IntType_nxt = INTTYPE_SWI2;
         else
             IntType_nxt = INTTYPE_SWI;        


### PR DESCRIPTION
and use the corresponding interrupt vector.
As it was, it used the vector for SWI.