### PR TITLE
AVMA should assert if writing CC

### DIFF
--- a/mc6809i.v
+++ b/mc6809i.v
@@ -3612,8 +3612,10 @@ begin
                 rAVMA = 1'b1;
                 rLIC = 1'b1;
             end
-            else
+            else if (RnWOut)
                 rAVMA = 1'b0;
+            else
+                rAVMA = 1'b1;
             CpuState_nxt  = NextState;
         end                                           
     end


### PR DESCRIPTION
On a full interrupt return, if AVMA is being used to inhibit DOut access, then this signal is being lowered prematurely during the stack write for the CC register. This causes a zero write (if that is what is being driven if bus is inhibited) for CC, causing the subsequent pull to fail to recover registers (since the E bit would return as 0), thus causing PC to not return from whence it came. I am not sure which way the silicon actually works, but it seems like a bug to me.